### PR TITLE
refactor: Minimize javascript on client side & contants variable usage

### DIFF
--- a/src/components/blog/BlogSection.tsx
+++ b/src/components/blog/BlogSection.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
-import { cn } from '@/lib/utils';
-import { BlogCard } from './BlogCard';
+import React, { useState } from "react";
+import { cn } from "@/lib/utils";
+import { BlogCard } from "./BlogCard";
+import { Frown } from "lucide-react";
 
 export interface BlogPost {
   id: string;
@@ -15,14 +16,28 @@ interface BlogSectionProps {
   posts: BlogPost[];
 }
 
-const categories = ['Semua', 'Lowongan', 'Beasiswa', 'Event', 'Kelas Bahasa', 'Berita'];
+const CATEGORIES = {
+  SEMUA: "Semua",
+  LOWONGAN: "Lowongan",
+  BEASISWA: "Beasiswa",
+  EVENT: "Event",
+  KELAS_BAHASA: "Kelas Bahasa",
+  BERITA: "Berita",
+} as const;
+
+type Category = (typeof CATEGORIES)[keyof typeof CATEGORIES];
+
+const categories: Category[] = Object.values(CATEGORIES);
 
 export const BlogSection: React.FC<BlogSectionProps> = ({ posts }) => {
-  const [selectedCategory, setSelectedCategory] = useState('Semua');
+  const [selectedCategory, setSelectedCategory] = useState<Category>(
+    CATEGORIES.SEMUA,
+  );
 
-  const filteredPosts = selectedCategory === 'Semua' 
-    ? posts 
-    : posts.filter(post => post.category === selectedCategory);
+  const filteredPosts =
+    selectedCategory === CATEGORIES.SEMUA
+      ? posts
+      : posts.filter((post) => post.category === selectedCategory);
 
   const handleCardClick = (link?: string) => {
     if (link) {
@@ -35,8 +50,10 @@ export const BlogSection: React.FC<BlogSectionProps> = ({ posts }) => {
       <div className="w-full max-w-[1040px] mx-auto">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between w-full mb-12">
           <div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-10">
-            <h2 className="text-[24px] md:text-[32px] font-bold text-gray-900 leading-none">Blog</h2>
-            
+            <h2 className="text-[24px] md:text-[32px] font-bold text-gray-900 leading-none">
+              Blog
+            </h2>
+
             <div className="overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
               <div className="flex items-center gap-4 w-max md:w-auto pb-2 md:pb-0">
                 {categories.map((category, index) => (
@@ -45,9 +62,9 @@ export const BlogSection: React.FC<BlogSectionProps> = ({ posts }) => {
                       onClick={() => setSelectedCategory(category)}
                       className={cn(
                         "text-[15px] md:text-[17px] text-gray-900 transition-all whitespace-nowrap",
-                        selectedCategory === category 
-                          ? "font-semibold text-blue-600 border-b-2 border-blue-600" 
-                          : "font-normal hover:opacity-70"
+                        selectedCategory === category
+                          ? "font-semibold text-blue-600 border-b-2 border-blue-600 cursor-pointer"
+                          : "font-normal hover:opacity-70 cursor-pointer",
                       )}
                     >
                       {category}
@@ -60,25 +77,34 @@ export const BlogSection: React.FC<BlogSectionProps> = ({ posts }) => {
               </div>
             </div>
           </div>
-          
-          <button className="hidden md:block text-[17px] text-gray-900 hover:opacity-70 transition-opacity whitespace-nowrap">
+
+          <button className="hidden md:block text-[17px] text-gray-900 hover:opacity-70 transition-opacity whitespace-nowrap cursor-pointer">
             Lainnya
           </button>
         </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filteredPosts.map((post) => (
-            <BlogCard
-              key={post.id}
-              category={post.category}
-              date={post.date}
-              imageUrl={post.imageUrl}
-              title={post.title}
-              onClick={() => handleCardClick(post.link)}
-            />
-          ))}
-        </div>
+        {filteredPosts.length === 0 ? (
+          <div className="text-center text-gray-500 mt-10">
+            <p className="flex items-center justify-center gap-1.5">
+              Oops! Belum ada postingan untuk kategori ini
+              <Frown className="inline-block" />.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredPosts.map((post) => (
+              <BlogCard
+                key={post.id}
+                category={post.category}
+                date={post.date}
+                imageUrl={post.imageUrl}
+                title={post.title}
+                onClick={() => handleCardClick(post.link)}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </section>
   );
 };
+

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -1,11 +1,8 @@
-import { GithubButton } from "../../components/github-button";
-import {GITHUB_URL} from "../../constants/urls"
+import { GithubButton } from "@/components/github-button";
+import { GITHUB_URL } from "@/constants/urls";
+import { EMAIL } from "@/constants/contacts";
 
 export function AboutSection() {
-  const handleGithubClick = () => {
-    window.open(GITHUB_URL, "_blank");
-  };
-
   return (
     <section className="py-10 md:py-16">
       <div className="container mx-auto px-4 md:px-6">
@@ -29,13 +26,17 @@ export function AboutSection() {
         </div>
 
         <div className="flex flex-col sm:flex-row items-center justify-center mt-10 gap-6 sm:gap-6">
-          <GithubButton
-            className="px-6 py-2 text-base w-full sm:w-auto"
-            ariaLabel="Jadi kontributor GitHub untuk #KaburAjaDulu"
-            onClick={handleGithubClick}
-          />
           <a
-            href="mailto:kaburajadulusocials@gmail.com"
+            href={GITHUB_URL}
+            target="_blank"
+            className="flex items-center justify-center"
+            rel="noopener noreferrer"
+            aria-label="Jadi kontributor GitHub untuk #KaburAjaDulu"
+          >
+            <GithubButton className="px-6 py-2 text-base w-full sm:w-auto" />
+          </a>
+          <a
+            href={`mailto:${EMAIL}`}
             className="text-base underline decoration-1 hover:text-primary transition-colors mt-2 sm:mt-0"
             aria-label="Berikan saran atau masukan di GitHub"
           >

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -1,8 +1,9 @@
 import { GithubButton } from "../../components/github-button";
+import {GITHUB_URL} from "../../constants/urls"
 
 export function AboutSection() {
   const handleGithubClick = () => {
-    window.open("https://github.com/KaburAjaDul/kaburajadulu", "_blank");
+    window.open(GITHUB_URL, "_blank");
   };
 
   return (

--- a/src/components/home/CTASection.tsx
+++ b/src/components/home/CTASection.tsx
@@ -2,25 +2,24 @@ import { DISCORD_URL } from "@/constants/urls";
 import { DiscordButton } from "../discord-button";
 
 export function CTASection() {
-  const handleDiscordClick = () => {
-    window.open(DISCORD_URL, "_blank");
-  };
-
   return (
     <section className="py-10 md:py-16">
       <div className="container mx-auto text-center px-4 md:px-6">
         <h2 className="text-3xl font-bold mb-6">
           #KaburAjaDulu, Kalo Bukan Sekarang, Mau Kapan?
         </h2>
-        <DiscordButton
-          className="shadow-dc"
-          onClick={handleDiscordClick}
-          ariaLabel="Gabung dengan komunitas #KaburAjaDulu di Discord"
-        />
+        <a
+          href={DISCORD_URL}
+          className="flex items-center justify-center"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Gabung dengan komunitas #KaburAjaDulu di Discord"
+        >
+          <DiscordButton className="shadow-dc" />
+        </a>
       </div>
     </section>
   );
 }
 
 export default CTASection;
-

--- a/src/components/home/CTASection.tsx
+++ b/src/components/home/CTASection.tsx
@@ -1,9 +1,10 @@
-import { DiscordButton } from '../discord-button'
+import { DISCORD_URL } from "@/constants/urls";
+import { DiscordButton } from "../discord-button";
 
 export function CTASection() {
   const handleDiscordClick = () => {
-    window.open('https://discord.com/invite/KaburAjaDulu', '_blank')
-  }
+    window.open(DISCORD_URL, "_blank");
+  };
 
   return (
     <section className="py-10 md:py-16">
@@ -11,14 +12,15 @@ export function CTASection() {
         <h2 className="text-3xl font-bold mb-6">
           #KaburAjaDulu, Kalo Bukan Sekarang, Mau Kapan?
         </h2>
-        <DiscordButton 
-          className="shadow-dc" 
+        <DiscordButton
+          className="shadow-dc"
           onClick={handleDiscordClick}
           ariaLabel="Gabung dengan komunitas #KaburAjaDulu di Discord"
         />
       </div>
     </section>
-  )
+  );
 }
 
-export default CTASection
+export default CTASection;
+

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -1,32 +1,41 @@
-import { DISCORD_URL } from '@/constants/urls'
-import { DiscordButton } from '../discord-button'
+import { DISCORD_URL } from "@/constants/urls";
+import { DiscordButton } from "../discord-button";
 
 export function HeroSection() {
-  const handleDiscordClick = () => {
-    if (typeof window !== 'undefined') {
-      window.open(DISCORD_URL, '_blank')
-    }
-  }
-
   return (
     <section className="py-10 md:py-24">
       <div className="container mx-auto text-center px-4 md:px-6">
         <h1 className="text-4xl md:text-5xl font-extrabold mb-4 md:mb-6">
-          &quot;Pengen <span className="text-primary">Kabur</span> ke Luar Negeri? Gaskeun!&quot;
+          &quot;Pengen <span className="text-primary">Kabur</span> ke Luar
+          Negeri? Gaskeun!&quot;
         </h1>
         <p className="text-lg md:text-xl font-light max-w-3xl mx-auto mb-8">
-        Kalau di sini susah maju, mungkin saatnya lihat ke tempat lain. <strong className="font-bold">#KaburAjaDulu</strong> bantu lo cari jalan buat kerja, kuliah, atau sekadar explore dunia. <strong className="font-bold">Job abroad, event keren, komunitas, kelas bahasa, beasiswa, sampe blog penuh tips & trik semua</strong> ada di sini!
+          Kalau di sini susah maju, mungkin saatnya lihat ke tempat lain.{" "}
+          <strong className="font-bold">#KaburAjaDulu</strong> bantu lo cari
+          jalan buat kerja, kuliah, atau sekadar explore dunia.{" "}
+          <strong className="font-bold">
+            Job abroad, event keren, komunitas, kelas bahasa, beasiswa, sampe
+            blog penuh tips & trik semua
+          </strong>{" "}
+          ada di sini!
         </p>
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-          <DiscordButton 
-            variant="filled" 
-            className="shadow-dc w-full sm:w-auto" 
-            onClick={handleDiscordClick}
-            ariaLabel="Gabung server Discord #KaburAjaDulu"
-          />
-          <a 
-            href="https://discord.com/company" 
-            target='_blank'
+          <a
+            href={DISCORD_URL}
+            className="flex items-center justify-center"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Gabung dengan komunitas #KaburAjaDulu di Discord"
+          >
+            <DiscordButton
+              variant="filled"
+              className="shadow-dc w-full sm:w-auto"
+              ariaLabel="Gabung server Discord #KaburAjaDulu"
+            />
+          </a>
+          <a
+            href="https://discord.com/company"
+            target="_blank"
             className="text-primary hover:underline font-medium mt-2 sm:mt-0"
             aria-label="Pelajari tentang aplikasi Discord"
           >
@@ -35,7 +44,7 @@ export function HeroSection() {
         </div>
       </div>
     </section>
-  )
+  );
 }
 
-export default HeroSection
+export default HeroSection;

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -1,14 +1,15 @@
+import { DISCORD_URL } from '@/constants/urls'
 import { DiscordButton } from '../discord-button'
 
 export function HeroSection() {
   const handleDiscordClick = () => {
     if (typeof window !== 'undefined') {
-      window.open('https://discord.com/invite/KaburAjaDulu', '_blank')
+      window.open(DISCORD_URL, '_blank')
     }
   }
 
   return (
-    <section className="py-10 md:py-16 md:py-24">
+    <section className="py-10 md:py-24">
       <div className="container mx-auto text-center px-4 md:px-6">
         <h1 className="text-4xl md:text-5xl font-extrabold mb-4 md:mb-6">
           &quot;Pengen <span className="text-primary">Kabur</span> ke Luar Negeri? Gaskeun!&quot;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,38 +1,43 @@
-import { DiscordButton } from '../discord-button'
-import { DISCORD_URL } from '@/constants/urls'
+import { DiscordButton } from "../discord-button";
+import { DISCORD_URL } from "@/constants/urls";
 
 export function Navbar() {
-  const handleDiscordClick = () => {
-    if (typeof window !== 'undefined') {
-      window.open(DISCORD_URL, '_blank')
-    }
-  }
-
   return (
     <nav className="container mx-auto px-4 sm:px-6 lg:px-8 py-3 sm:py-4 flex items-center justify-between">
       {/* Logo */}
-      <a href="/" className="font-bold text-lg flex items-center" aria-label="Kembali ke halaman utama">
-        <img 
-          src="/icon.svg" 
+      <a
+        href="/"
+        className="font-bold text-lg flex items-center"
+        aria-label="Kembali ke halaman utama"
+      >
+        <img
+          src="/icon.svg"
           alt="KaburAjaDulu Logo"
           width={140}
           height={28}
           className="w-32 sm:w-40 h-auto"
         />
       </a>
-      
+
       {/* Navigation Links */}
       <div className="flex items-center">
-        <DiscordButton 
-          variant="outlined" 
-          className="text-sm sm:text-base px-3 sm:px-4 py-2" 
-          onClick={handleDiscordClick}
-          ariaLabel="Gabung dengan komunitas #KaburAjaDulu di Discord"
-          iconOnly={true}
-        />
+        <a
+          href={DISCORD_URL}
+          className="flex items-center justify-center"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Gabung dengan komunitas #KaburAjaDulu di Discord"
+        >
+          <DiscordButton
+            variant="outlined"
+            className="text-sm sm:text-base px-3 sm:px-4 py-2"
+            iconOnly={true}
+          />
+        </a>
       </div>
     </nav>
-  )
+  );
 }
 
-export default Navbar
+export default Navbar;
+

--- a/src/constants/contacts.ts
+++ b/src/constants/contacts.ts
@@ -1,0 +1,1 @@
+export const EMAIL = "kaburajadulusocials@gmail.com" // 

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,4 +1,3 @@
 // Application URLs
 export const DISCORD_URL = "https://discord.com/invite/KaburAjaDulu";
-
-// Add other URLs here as needed
+export const GITHUB_URL = "https://github.com/KaburAjaDul/kaburajadulu";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,13 +18,13 @@ const gscVerification = import.meta.env.GOOGLE_SITE_VERIFICATION;
   title="#KaburAjaDulu | Jelajahi Peluang Internasional"
   gscVerification={gscVerification}
 >
-  <Navbar client:load />
+  <Navbar />
   <main>
-    <HeroSection client:load />
-    <DestinationShowcase client:load />
-    <AboutSection client:load />
-    <BlogSection client:load posts={blogPosts} />
-    <CTASection client:load />
+    <HeroSection />
+    <DestinationShowcase />
+    <AboutSection />
+    <BlogSection client:idle posts={blogPosts} />
+    <CTASection />
   </main>
-  <Footer client:load />
+  <Footer/>
 </Layout>


### PR DESCRIPTION
## PR Description

The main goal of this PR is to minimize javascript code by removing onClick button when we only need to link to other websites (i.e. Discord and Github Button). Instead we can simply just use `</a>` element to link other websites. Thus we the client side doesn't require javascript code except for the blog sections.

`index.astro`
```ts
  <Navbar /> // Don't need client:load anymore
  <main>
    <HeroSection /> // Don't need client:load anymore
    <DestinationShowcase /> // Don't need client:load anymore
    <AboutSection /> // Don't need client:load anymore
    <BlogSection client:idle posts={blogPosts} /> // Change to client:idle because it's not a high priority
    <CTASection /> // Don't need client:load anymore
  </main>
  <Footer/> // Don't need client:load anymore
```

### Changes

- Use URL constant whenever possible
- Blog categories changed from array of strings into a constant type instead
- Wrap Discord and Github button with `</a>` to link other websites